### PR TITLE
feat #116 - 기숙사 게시글 이미지, 게시글 모집 인원 정보 데이터 변경

### DIFF
--- a/src/main/java/org/capstone/maru/dto/DormitoryRoomPostDetailDto.java
+++ b/src/main/java/org/capstone/maru/dto/DormitoryRoomPostDetailDto.java
@@ -2,6 +2,7 @@ package org.capstone.maru.dto;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.Builder;
@@ -16,7 +17,7 @@ public record DormitoryRoomPostDetailDto(
     String content,
     String publisherGender,
     FeatureCardDto roomMateCard,
-    List<MemberAccountDto> participants,
+    List<SimpleMemberProfileDto> participants,
     Set<RoomImageDto> roomImages,
     MemberAccountDto publisherAccount,
     Address address,
@@ -33,6 +34,7 @@ public record DormitoryRoomPostDetailDto(
     public static DormitoryRoomPostDetailDto from(
         DormitoryRoomPost entity,
         Boolean isScrapped,
+        List<String> scrappedMemberIds,
         Long scrapCount,
         Long viewCount
     ) {
@@ -46,7 +48,16 @@ public record DormitoryRoomPostDetailDto(
                 entity.getSharedRoomPostRecruits()
                       .stream()
                       .map(Participation::getRecruitedMemberAccount)
-                      .map(MemberAccountDto::from)
+                      .map(memberAccount ->
+                          SimpleMemberProfileDto
+                              .from(
+                                  memberAccount,
+                                  scrappedMemberIds
+                                      .stream()
+                                      .anyMatch(memberId -> Objects.equals(memberId,
+                                          memberAccount.getMemberId()))
+                              )
+                      )
                       .toList()
             )
             .roomImages(

--- a/src/main/java/org/capstone/maru/dto/SimpleMemberProfileDto.java
+++ b/src/main/java/org/capstone/maru/dto/SimpleMemberProfileDto.java
@@ -1,0 +1,25 @@
+package org.capstone.maru.dto;
+
+import lombok.Builder;
+import org.capstone.maru.domain.MemberAccount;
+
+@Builder
+public record SimpleMemberProfileDto(
+    String memberId,
+    String nickname,
+    String profileImageFileName,
+    String birthYear,
+    Boolean isScrapped
+) {
+
+    public static SimpleMemberProfileDto from(MemberAccount entity, Boolean isScrapped) {
+        return SimpleMemberProfileDto
+            .builder()
+            .memberId(entity.getMemberId())
+            .nickname(entity.getNickname())
+            .profileImageFileName(entity.getProfileImage().getFileName())
+            .birthYear(entity.getBirthYear())
+            .isScrapped(isScrapped)
+            .build();
+    }
+}

--- a/src/main/java/org/capstone/maru/dto/StudioRoomPostDetailDto.java
+++ b/src/main/java/org/capstone/maru/dto/StudioRoomPostDetailDto.java
@@ -2,6 +2,7 @@ package org.capstone.maru.dto;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.Builder;
@@ -16,7 +17,7 @@ public record StudioRoomPostDetailDto(
     String content,
     String publisherGender,
     FeatureCardDto roomMateCard,
-    List<MemberAccountDto> participants,
+    List<SimpleMemberProfileDto> participants,
     Set<RoomImageDto> roomImages,
     MemberAccountDto publisherAccount,
     Address address,
@@ -33,7 +34,8 @@ public record StudioRoomPostDetailDto(
 
     public static StudioRoomPostDetailDto from(
         StudioRoomPost entity,
-        Boolean isScrapped,
+        Boolean isPostScrapped,
+        List<String> scrappedMemberIds,
         Long scrapCount,
         Long viewCount
     ) {
@@ -47,7 +49,16 @@ public record StudioRoomPostDetailDto(
                 entity.getSharedRoomPostRecruits()
                       .stream()
                       .map(Participation::getRecruitedMemberAccount)
-                      .map(MemberAccountDto::from)
+                      .map(memberAccount ->
+                          SimpleMemberProfileDto
+                              .from(
+                                  memberAccount,
+                                  scrappedMemberIds
+                                      .stream()
+                                      .anyMatch(memberId -> Objects.equals(memberId,
+                                          memberAccount.getMemberId()))
+                              )
+                      )
                       .toList()
             )
             .roomImages(
@@ -61,7 +72,7 @@ public record StudioRoomPostDetailDto(
             .address(entity.getAddress())
             .roomInfo(RoomInfoDto.from(entity.getRoomInfo()))
             .recruitmentCapacity(entity.getRecruitmentCapacity())
-            .isScrapped(isScrapped)
+            .isScrapped(isPostScrapped)
             .scrapCount(scrapCount)
             .viewCount(viewCount)
             .createdAt(entity.getCreatedAt())

--- a/src/main/java/org/capstone/maru/dto/response/ParticipantResponse.java
+++ b/src/main/java/org/capstone/maru/dto/response/ParticipantResponse.java
@@ -1,19 +1,25 @@
 package org.capstone.maru.dto.response;
 
 import lombok.Builder;
-import org.capstone.maru.dto.MemberAccountDto;
+import org.capstone.maru.dto.SimpleMemberProfileDto;
 
 @Builder
 public record ParticipantResponse(
     String memberId,
-    String profileImageFileName
+    String nickname,
+    String profileImageFileName,
+    String birthYear,
+    Boolean isScrapped
 ) {
 
-    public static ParticipantResponse from(MemberAccountDto participantDto) {
+    public static ParticipantResponse from(SimpleMemberProfileDto dto) {
         return ParticipantResponse
             .builder()
-            .memberId(participantDto.memberId())
-            .profileImageFileName(participantDto.profileImageFileName())
+            .memberId(dto.memberId())
+            .nickname(dto.nickname())
+            .profileImageFileName(dto.profileImageFileName())
+            .birthYear(dto.birthYear())
+            .isScrapped(dto.isScrapped())
             .build();
     }
 

--- a/src/main/java/org/capstone/maru/repository/postgre/FollowRepository.java
+++ b/src/main/java/org/capstone/maru/repository/postgre/FollowRepository.java
@@ -1,12 +1,17 @@
 package org.capstone.maru.repository.postgre;
 
+import java.util.List;
 import java.util.Optional;
 import org.capstone.maru.domain.Follow;
 import org.capstone.maru.domain.MemberAccount;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface FollowRepository extends JpaRepository<Follow, Long> {
 
     Optional<Follow> findByFollowerAndFollowing(MemberAccount followerAccount,
         MemberAccount followingAccount);
+
+    @Query("select fol.following.memberId from Follow fol where fol.follower.memberId = :followerId")
+    List<String> findFollowingIdsByFollowerId(String followerId);
 }

--- a/src/main/java/org/capstone/maru/repository/postgre/querydsl/StudioRoomPostCustomRepositoryImpl.java
+++ b/src/main/java/org/capstone/maru/repository/postgre/querydsl/StudioRoomPostCustomRepositoryImpl.java
@@ -24,6 +24,7 @@ import org.springframework.util.StringUtils;
 
 import static org.capstone.maru.domain.QStudioRoomPost.studioRoomPost;
 import static org.capstone.maru.domain.QRoomInfo.roomInfo;
+import static org.capstone.maru.domain.QRecommend.recommend;
 
 public class StudioRoomPostCustomRepositoryImpl implements
     org.capstone.maru.repository.postgre.querydsl.StudioRoomPostCustomRepository {

--- a/src/main/java/org/capstone/maru/service/StudioRoomPostService.java
+++ b/src/main/java/org/capstone/maru/service/StudioRoomPostService.java
@@ -18,6 +18,7 @@ import org.capstone.maru.dto.StudioRoomPostDto;
 import org.capstone.maru.dto.request.SearchFilterRequest;
 import org.capstone.maru.exception.PostNotFoundException;
 import org.capstone.maru.exception.RestErrorCode;
+import org.capstone.maru.repository.postgre.FollowRepository;
 import org.capstone.maru.repository.postgre.MemberAccountRepository;
 import org.capstone.maru.repository.postgre.ScrapPostRepository;
 import org.capstone.maru.repository.postgre.StudioRoomPostRepository;
@@ -39,6 +40,7 @@ public class StudioRoomPostService {
     private final MemberAccountRepository memberAccountRepository;
     private final ScrapPostRepository scrapPostRepository;
     private final ViewPostRepository viewPostRepository;
+    private final FollowRepository followRepository;
 
     private final ViewCountService viewCountService;
     private final S3FileService s3FileService;
@@ -134,10 +136,21 @@ public class StudioRoomPostService {
             .map(ScrapPostView::getIsScrapped)
             .orElse(false);
         final Long scrapCount = scrapPostRepository.countByScrappedIdAndIsScrapped(postId);
+        List<String> scrappedMemberIds = followRepository.findFollowingIdsByFollowerId(memberId);
 
         // 조회수 +1 & 게시글 총 조회수
         Long viewCount = viewCountService.increaseValue(SharedViewCountCacheKey.from(postId));
 
+        resultEntity
+            .getSharedRoomPostRecruits()
+            .stream()
+            .map(Participation::getRecruitedMemberAccount)
+            .map(MemberAccount::getProfileImage)
+            .forEach(
+                profileImage -> profileImage.updateFileName(
+                    s3FileService.getPreSignedUrlForLoad(profileImage.getFileName())
+                )
+            );
         resultEntity
             .getRoomImages()
             .forEach(
@@ -146,7 +159,8 @@ public class StudioRoomPostService {
                         .getPreSignedUrlForLoad(roomImage.getFileName())
                 )
             );
-        return StudioRoomPostDetailDto.from(resultEntity, isScrapped, scrapCount, viewCount);
+        return StudioRoomPostDetailDto.from(resultEntity, isScrapped, scrappedMemberIds, scrapCount,
+            viewCount);
     }
 
     public void saveStudioRoomPost(


### PR DESCRIPTION
## Overview
- 기숙사 게시글 이미지 url을 pre-signed url로 응답
- 게시글 모집 인원 정보 응답 데이터 변경
<!-- A clear and concise description about the feature -->

## Issues

<!-- Add a issues that referenced this pull request -->
